### PR TITLE
chore: update podzilla-utils-lib version to v1.1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.github.Podzilla</groupId>
             <artifactId>podzilla-utils-lib</artifactId>
-            <version>v1.1.12</version>
+            <version>v1.1.13</version>
         </dependency>
 
         <!-- Validation API & Implementation -->


### PR DESCRIPTION
This pull request includes a minor update to the `pom.xml` file to upgrade the `podzilla-utils-lib` dependency from version `v1.1.12` to `v1.1.13`.